### PR TITLE
feat: 사이클 브랜치 생성 시 워크트리 우선 안내 추가

### DIFF
--- a/.claude/skills/cycle/SKILL.md
+++ b/.claude/skills/cycle/SKILL.md
@@ -46,7 +46,15 @@ Phase 7: PR 머지 + 브랜치 정리
    - 라벨 자동 매핑 (feat, fix, docs, refactor, chore)
    - 라벨 미존재 시 자동 생성
    - 브랜치명: `{타입}/{이슈번호}`
-5. 브랜치 생성 및 체크아웃
+5. 브랜치 생성 (사용자에게 방식 제안):
+   - **워크트리 (권장)**: 로컬 상태 보존, 별도 디렉토리에서 작업
+     ```bash
+     git worktree add ../{프로젝트}-{타입}-{이슈번호} -b {타입}/{이슈번호}
+     ```
+   - **직접 체크아웃**: 현재 디렉토리에서 작업
+     1. uncommitted changes 확인 → stash/commit 안내
+     2. `git checkout main && git pull`
+     3. `git checkout -b {타입}/{이슈번호}`
 
 ### Phase 2: 플랜 작성
 
@@ -119,10 +127,9 @@ Phase 7: PR 머지 + 브랜치 정리
    ```bash
    gh pr merge {PR번호} --merge
    ```
-2. 타겟 브랜치로 이동 및 최신화:
-   ```bash
-   git checkout {타겟브랜치} && git pull
-   ```
+2. 작업 환경 정리:
+   - **워크트리 사용 시**: `git worktree remove ../{워크트리 경로}`
+   - **직접 체크아웃 시**: `git checkout {타겟브랜치} && git pull`
 3. 사이클 완료 보고
 
 ## 규칙

--- a/.claude/skills/github-issue/SKILL.md
+++ b/.claude/skills/github-issue/SKILL.md
@@ -38,10 +38,9 @@ GitHub 이슈 생성 및 브랜치 세팅 워크플로우
    - [ ] 항목 2
    ```
 5. `gh issue create` 실행
-6. 이슈 번호로 브랜치 자동 생성 및 체크아웃:
-   ```bash
-   git checkout -b feature/{번호}
-   ```
+6. 브랜치 생성 (사용자에게 방식 제안):
+   - **워크트리 (권장)**: `git worktree add ../{프로젝트}-{타입}-{번호} -b {타입}/{번호}`
+   - **직접 체크아웃**: uncommitted changes 확인 → `git checkout main && git pull` → `git checkout -b {타입}/{번호}`
 
 ## 브랜치 명명 규칙
 


### PR DESCRIPTION
## 요약

- 사이클 Phase 1 브랜치 생성 시 워크트리(권장)/직접 체크아웃 선택지 제시
- Phase 7에 워크트리/체크아웃 방식별 정리 단계 분기 추가
- github-issue 스킬에도 동일 패턴 적용

## 변경 파일

- `.claude/skills/cycle/SKILL.md`
- `.claude/skills/github-issue/SKILL.md`

## 자가 검증

- [x] 변경 파일 2개 (플랜과 일치)
- [x] 빌드/테스트: 해당없음 (마크다운 스킬 파일)
- [x] PR 정상 생성 확인

Closes #31