### PR TITLE
feat!: .devex/state 리네임 + usage-tracker 흡수 (5.0.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ PlantUML 사용 시: `example.puml` → `example.svg` 필수 생성
 |------|------|------|
 | 워크트리 생성 | `scripts/worktree-create.sh <state-file>` | clone-on-demand + 워크트리 일괄 생성 + vcs.xml 매핑 |
 | 워크트리 정리 | `scripts/worktree-cleanup.sh` | bare clone 포함 정리 |
-| state 파일 포맷 | `.omc/state/org-flow-{ticket}.json` | 경로 컨벤션 (이름 잔재, 리네임은 별 이슈) |
+| state 파일 포맷 | `.devex/state/org-flow-{ticket}.json` | 경로 컨벤션 (이름 잔재, 리네임은 별 이슈) |
 | 하네스 자체 워크트리 | Claude Code `Agent` 도구의 `isolation: "worktree"` | 단발 isolation 작업용 — 위 스크립트와 무관 |
 
 분기 판단:
@@ -132,7 +132,7 @@ PlantUML 사용 시: `example.puml` → `example.svg` 필수 생성
 - 같은 레포의 여러 PR 병렬 검토 → `scripts/worktree-create.sh`
 - 단발 isolation (실험·임시 빌드) → `Agent` 도구 isolation
 
-`.omc/state/` 경로명은 이전 자산 호환을 위해 유지한다. 추후 `.devex/state/` 로 리네임할 가능성이 있으며 별 이슈로 추적한다.
+`.devex/state/` 경로명은 이전 자산 호환을 위해 유지한다. 추후 `.devex/state/` 로 리네임할 가능성이 있으며 별 이슈로 추적한다.
 
 ---
 

--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -6,7 +6,7 @@
 #
 # 사용법:
 #   ./worktree-cleanup.sh <state-file>              # 티켓 단위 정리 (기본)
-#     state-file: .omc/state/org-flow-{ticket}.json
+#     state-file: .devex/state/org-flow-{ticket}.json
 #
 #   ./worktree-cleanup.sh --sweep-stale [--apply]   # stale state/고아 bare clone 정리
 #     --apply 없이 실행하면 dry-run (감지만 출력).

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -5,7 +5,7 @@
 # 레포가 없으면 bare clone → worktree 생성. 정리 시 bare clone도 삭제.
 #
 # 사용법: ./worktree-create.sh <state-file>
-#   state-file: .omc/state/org-flow-{ticket}.json
+#   state-file: .devex/state/org-flow-{ticket}.json
 #
 # 입력 JSON 구조 (필수 필드):
 #   ticket, primaryRepo, repos.{name}.{branch, base, worktree}

--- a/skills/org-flow/SKILL.md
+++ b/skills/org-flow/SKILL.md
@@ -84,7 +84,7 @@ org-flow가 이슈 트래커 API를 직접 호출하지 않는다.
 **Step 3: 워크트리 생성 (스크립트)**
 
 ```bash
-scripts/worktree-create.sh .omc/state/org-flow-{ticket}.json
+scripts/worktree-create.sh .devex/state/org-flow-{ticket}.json
 ```
 
 clone-on-demand: 레포가 없으면 bare clone → 워크트리 생성.
@@ -92,7 +92,7 @@ vcs.xml 매핑 자동 추가.
 
 **Step 4: 상태 저장**
 
-`.omc/state/org-flow-{ticket}.json`:
+`.devex/state/org-flow-{ticket}.json`:
 
 ```json
 {
@@ -145,7 +145,7 @@ vcs.xml 매핑 자동 추가.
 **Step 3: 워크트리 정리 (스크립트)**
 
 ```bash
-scripts/worktree-cleanup.sh .omc/state/org-flow-{ticket}.json
+scripts/worktree-cleanup.sh .devex/state/org-flow-{ticket}.json
 ```
 
 워크트리 제거 + bare clone 삭제 + vcs.xml 정리 + 상태 파일 삭제.

--- a/skills/usage-checkpoint/SKILL.md
+++ b/skills/usage-checkpoint/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: usage-checkpoint
+description: Mark a checkpoint in the active task to segment usage by work phase. 트리거 "체크포인트", "checkpoint", "사용량 분기".
+---
+
+# usage:checkpoint
+
+Mark a checkpoint to split usage into segments. Each checkpoint captures cumulative usage at that point; the difference between consecutive checkpoints becomes the segment usage.
+
+## Trigger
+
+- "usage checkpoint {label}"
+- "체크포인트 {label}"
+- "구간 표시"
+
+## Parameters
+
+- **label** (required): Segment name (e.g., "Step 4 C-001 작성", "BE 교차검증")
+- **taskId** (optional): Task to checkpoint. If omitted and only one active task, uses that one.
+
+## Procedure
+
+### 1. Load tasks and identify target
+
+```bash
+cat "$HOME/.claude/usage-tracker/tasks.json"
+```
+
+Find target task (active only). If ambiguous, list and ask.
+
+### 2. Query current cumulative usage
+
+```bash
+ccusage session --since {task.startedAt as YYYYMMDD} --json --breakdown
+```
+
+Match sessions by task's binding projects. Calculate cumulative totals:
+- **cumulativeTokens**: sum of totalTokens across matched sessions
+- **cumulativeCost**: sum of totalCost
+
+### 3. Calculate segment usage
+
+If previous checkpoints exist, segment = current cumulative - last checkpoint cumulative.
+If no previous checkpoints, segment = current cumulative - 0 (i.e., from task start).
+
+```
+segmentTokens = cumulativeTokens - lastCheckpoint.cumulativeTokens (or 0)
+segmentCost = cumulativeCost - lastCheckpoint.cumulativeCost (or 0)
+```
+
+### 4. Write checkpoint to tasks.json
+
+Add to the task's `checkpoints` array (create if not exists):
+
+```json
+{
+  "checkpoints": [
+    {
+      "label": "{label}",
+      "createdAt": "{ISO timestamp}",
+      "cumulativeTokens": 12345,
+      "cumulativeCost": 1.23,
+      "segmentTokens": 3456,
+      "segmentCost": 0.45
+    }
+  ]
+}
+```
+
+### 5. Output
+
+```
+[Usage Tracker] Checkpoint marked
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Task: {label}
+Checkpoint: {checkpoint.label}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+| Metric          | Segment      | Cumulative   |
+|-----------------|--------------|--------------|
+| Tokens          | {segTokens}  | {cumTokens}  |
+| Cost            | ${segCost}   | ${cumCost}   |
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Checkpoints so far: {count}
+```

--- a/skills/usage-complete/SKILL.md
+++ b/skills/usage-complete/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: usage-complete
+description: 작업을 완료 처리하고 최종 사용량 리포트를 생성합니다. 트리거 "작업 완료", "사용량 완료", "complete task".
+---
+
+# usage:complete
+
+추적 중인 작업을 완료 처리하고, 최종 사용량 리포트를 로컬에 저장합니다.
+
+## 트리거
+
+- "usage complete"
+- "usage done"
+- "작업 추적 종료"
+
+## 파라미터
+
+- **taskId** (선택): 완료할 작업. 생략 시 진행 중인 작업이 하나면 자동 선택하고, 여러 개면 사용자에게 확인합니다.
+- **summary** (선택): 작업 결과에 대한 간단한 설명.
+
+## 절차
+
+### 1. 작업 식별
+
+```bash
+cat "$HOME/.claude/usage-tracker/tasks.json"
+```
+
+대상 작업을 찾습니다. 모호한 경우 진행 중인 작업 목록을 보여주고 확인합니다.
+
+### 2. 최종 사용량 데이터 조회
+
+snap과 동일 — ccusage를 조회하여 집계합니다.
+
+```bash
+ccusage session --since {task.startedAt as YYYYMMDD} --json --breakdown
+```
+
+### 3. 리포트 생성
+
+`~/.claude/usage-tracker/reports/{taskId}-{date}.md`에 마크다운 리포트를 생성합니다:
+
+```markdown
+# 사용량 리포트: {label}
+
+## 요약
+
+- **작업명**: {label}
+- **작업 방식**: {approach}
+- **기간**: {startedAt} ~ {completedAt}
+- **소요 일수**: {days}일
+- **태그**: {tags}
+
+## 토큰 사용량
+
+| 항목 | 값 |
+|------|-----|
+| 총 비용 | ${cost} |
+| 총 토큰 | {tokens} |
+| 입력 토큰 | {input} |
+| 출력 토큰 | {output} |
+| 캐시 읽기 | {cacheRead} |
+| 캐시 생성 | {cacheCreate} |
+
+## 구간별 사용량
+
+체크포인트가 기록된 경우에만 이 섹션을 포함합니다.
+체크포인트가 없으면 이 섹션을 생략합니다.
+
+| # | 구간 | 토큰 | 비용 | 비율 |
+|---|------|------|------|------|
+| 1 | {checkpoint1.label} | {segmentTokens} | ${segmentCost} | {percent}% |
+| 2 | {checkpoint2.label} | {segmentTokens} | ${segmentCost} | {percent}% |
+| - | (마지막 체크포인트 이후) | {remainingTokens} | ${remainingCost} | {percent}% |
+| | **합계** | **{totalTokens}** | **${totalCost}** | **100%** |
+
+구간별 비율은 각 구간의 비용을 총 비용으로 나눈 값입니다.
+"마지막 체크포인트 이후" 구간은 마지막 체크포인트의 누적값과 최종 누적값의 차이입니다.
+
+## 모델별 내역
+
+| 모델 | 비용 | 토큰 |
+|------|------|------|
+| {model} | ${cost} | {tokens} |
+
+## 세션 목록
+
+| # | 세션 ID | 등록일 | 자동 등록 |
+|---|---------|--------|-----------|
+| 1 | {id} | {date} | {예/아니오} |
+
+## 효율 지표
+
+- **일일 비용**: ${cost/days}
+- **세션당 출력 토큰**: {output/sessions}
+- **캐시 적중률**: {cacheRead / (cacheRead + cacheCreate + input)}%
+
+## 메모
+
+{사용자가 제공한 summary}
+```
+
+### 4. tasks.json 업데이트
+
+작업 상태를 "completed"로 변경하고, completedAt 타임스탬프를 추가합니다.
+
+### 5. 결과 출력
+
+```
+[Usage Tracker] 작업이 완료되었습니다
+- 리포트 저장: ~/.claude/usage-tracker/reports/{taskId}-{date}.md
+- 총 비용: ${cost}
+- 소요 기간: {days}일
+- 세션 수: {count}
+```
+
+리포트 전체 내용도 함께 출력합니다.

--- a/skills/usage-report/SKILL.md
+++ b/skills/usage-report/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: usage-report
+description: 모든 추적된 작업의 비교 대시보드를 표시합니다. 트리거 "사용량 리포트", "report", "대시보드".
+---
+
+# usage:report
+
+모든 추적된 작업의 비용을 비교하는 대시보드를 출력한다.
+
+## Trigger
+
+- "usage report"
+- "usage dashboard"
+- "작업 비교"
+
+## Parameters
+
+- **filter** (optional): "active", "completed", "all" (default: "all")
+- **sort** (optional): "cost", "date", "efficiency" (default: "date")
+
+## Procedure
+
+### 1. Load all tasks
+
+```bash
+cat "$HOME/.claude/usage-tracker/tasks.json"
+```
+
+### 2. Query ccusage
+
+```bash
+ccusage session --since {earliest task startedAt as YYYYMMDD} --json --breakdown
+```
+
+각 task의 sessions 배열에서 session ID를 매칭하여 해당 task에 속하는 비용만 집계한다.
+
+**매칭 로직:**
+- task의 bindings[].project와 ccusage의 sessionId를 매칭
+- 같은 프로젝트에 여러 작업이 있을 경우, 세션 시작 시간과 task의 sessions[].id로 구분
+
+### 3. Output comparison table
+
+```
+[Usage Tracker] Dashboard
+
+| Task | Approach | Cost | Tokens | Sessions | Days | $/Day | Status |
+|------|----------|------|--------|----------|------|-------|--------|
+| {label} | {approach} | ${cost} | {tokens} | {count} | {days} | ${perDay} | {status} |
+
+Total tracked cost: ${totalCost}
+```
+
+### 4. Approach comparison (if multiple approaches exist)
+
+```
+[Approach Comparison]
+| Approach | Avg $/Task | Avg Tokens | Avg Sessions | Tasks |
+|----------|-----------|------------|-------------|-------|
+| manual   | ${avg}    | {avg}      | {avg}       | {n}   |
+| autopilot| ${avg}    | {avg}      | {avg}       | {n}   |
+```
+
+이 비교가 플러그인의 핵심 가치 -- 워크플로우 변경이 실제로 효율적인지 데이터로 증명한다.

--- a/skills/usage-snap/SKILL.md
+++ b/skills/usage-snap/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: usage-snap
+description: 활성 작업의 현재 토큰 사용량 스냅샷을 표시합니다. 트리거 "스냅샷", "snap", "현재 사용량".
+---
+
+# usage:snap
+
+Show how much the current (or specified) task has consumed so far.
+
+## Trigger
+
+- "usage snap"
+- "usage check"
+- "얼마나 썼나"
+- "토큰 사용량"
+
+## Parameters
+
+- **taskId** (optional): Specific task ID. If omitted, shows all active tasks.
+
+## Procedure
+
+### 1. Load tasks
+
+```bash
+cat "$HOME/.claude/usage-tracker/tasks.json"
+```
+
+Filter to active tasks (status = "active"). If taskId specified, filter to that one.
+
+### 2. Query ccusage for each task's sessions
+
+For each task, get session data:
+
+```bash
+ccusage session --since {task.startedAt as YYYYMMDD} --json --breakdown
+```
+
+Parse the JSON output. Match sessions by sessionId from the task's sessions array.
+
+**Matching logic:**
+- ccusage sessions have `sessionId` field (project path based, e.g., `-Users-nhn-git-project-aetherion-spec-guide`)
+- Task sessions have `id` field (UUID, e.g., `ebedca79-...`)
+- Match: task session `id` should appear as a JSONL filename under the ccusage session's project path
+- For simplicity: aggregate ALL ccusage sessions whose `sessionId` matches any of the task's binding projects
+
+### 3. Calculate metrics
+
+For each task:
+- **Total tokens**: sum of totalTokens across matched sessions
+- **Total cost**: sum of totalCost
+- **Input/Output/Cache breakdown**
+- **Session count**: number of sessions
+- **Duration**: startedAt to now
+- **Cost per day**: totalCost / days active
+
+### 4. Output
+
+```
+[Usage Tracker] Snapshot - {label}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+| Metric          | Value        |
+|-----------------|--------------|
+| Total Cost      | ${cost}      |
+| Total Tokens    | {tokens}     |
+| Input Tokens    | {input}      |
+| Output Tokens   | {output}     |
+| Cache Read      | {cacheRead}  |
+| Cache Create    | {cacheCreate}|
+| Sessions        | {count}      |
+| Duration        | {days}d      |
+| Cost/Day        | ${perDay}    |
+| Approach        | {approach}   |
+```
+
+If multiple active tasks, show a comparison table.

--- a/skills/usage-start/SKILL.md
+++ b/skills/usage-start/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: usage-start
+description: 새 작업의 사용량 추적을 시작합니다. 현재 세션을 기록하고 프로젝트+브랜치를 자동 등록합니다. 트리거 "사용량 추적", "추적 시작", "usage-start".
+---
+
+# usage:start
+
+Start tracking token usage for a new task.
+
+## Trigger
+
+- "usage start {label}"
+- "usage tracking {label}"
+- "작업 추적 시작 {label}"
+
+## Parameters
+
+- **label** (required): Human-readable task name (e.g., "GPU Live 프로젝트 CRUD 정책서")
+- **approach** (optional): Method being used (e.g., "manual", "workflow-runner", "autopilot"). Default: "manual"
+- **tags** (optional): Comma-separated tags for grouping (e.g., "spec,planning")
+
+## Procedure
+
+### 1. Detect current context
+
+```bash
+# Get current session ID from the most recent JSONL in this project
+PROJECT_PATH=$(pwd | sed "s|$HOME/||" | sed 's|/|-|g' | sed 's|^|-|')
+SESSION_ID=$(ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs basename | sed 's/.jsonl//')
+
+# Get current git branch (if git project)
+GIT_BRANCH=$(git branch --show-current 2>/dev/null || echo "none")
+```
+
+### 2. Read or create tasks.json
+
+```bash
+TRACKER_DIR="$HOME/.claude/usage-tracker"
+mkdir -p "$TRACKER_DIR/reports"
+cat "$TRACKER_DIR/tasks.json" 2>/dev/null || echo '{"tasks":{}}'
+```
+
+### 3. Generate task ID
+
+Create a short, URL-safe ID from the label:
+- Lowercase, replace spaces with hyphens
+- Max 30 chars
+- If duplicate, append `-2`, `-3`, etc.
+
+### 4. Write task entry
+
+Add to tasks.json:
+
+```json
+{
+  "tasks": {
+    "{taskId}": {
+      "label": "{label}",
+      "approach": "{approach}",
+      "tags": ["{tag1}", "{tag2}"],
+      "bindings": [
+        {
+          "project": "{PROJECT_PATH}",
+          "branch": "{GIT_BRANCH}"
+        }
+      ],
+      "sessions": [
+        {
+          "id": "{SESSION_ID}",
+          "addedAt": "{ISO timestamp}",
+          "auto": false
+        }
+      ],
+      "startedAt": "{ISO timestamp}",
+      "status": "active"
+    }
+  }
+}
+```
+
+### 5. Report
+
+Output:
+```
+[Usage Tracker] Task started
+- ID: {taskId}
+- Label: {label}
+- Approach: {approach}
+- Session: {SESSION_ID}
+- Binding: {project} @ {branch}
+```


### PR DESCRIPTION
Milestone: 5.0.0

## BREAKING CHANGES

- `.omc/state/` → `.devex/state/` 경로 컨벤션 변경 (OMC 잔재 제거)
- usage-tracker 5 스킬 흡수: `devex:usage-checkpoint`·`usage-complete`·`usage-start`·`usage-snap`·`usage-report`
- `usage-tracker:*` prefix 제거
- `claude-usage-tracker` 리포 archive 예정

## Test plan

- [ ] release 후 `devex:usage-start` 등 트리거 정상
- [ ] worktree-create.sh 가 `.devex/state/org-flow-{ticket}.json` 입력 인식
- [ ] 기존 `.omc/state/` 데이터 마이그레이션은 별 이슈 (5.0.0 범위 외)