### PR TITLE
feat: patch-hud 이관 — toolkit 의 compact-nowrap 패치를 devex 로 (#81)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.mjs\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/patch-hud.sh\" 2>/dev/null || true",
+            "timeout": 5
           }
         ]
       }

--- a/scripts/patch-hud.sh
+++ b/scripts/patch-hud.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# claude-hud compact 모드 wrap/truncate 회피 패치
+# 멱등성: 이미 적용됐으면 스킵, 원본 패턴 불일치 시 경고 (#81)
+#
+# 사용법: ./scripts/patch-hud.sh
+
+set -euo pipefail
+
+HUD_CACHE="$HOME/.claude/plugins/cache/claude-hud/claude-hud"
+
+LATEST=$(ls -1 "$HUD_CACHE" 2>/dev/null | sort -V | tail -1)
+if [ -z "$LATEST" ]; then
+  echo "⚠️  claude-hud 캐시 없음 — 스킵"
+  exit 0
+fi
+
+TARGET="$HUD_CACHE/$LATEST/src/render/index.ts"
+if [ ! -f "$TARGET" ]; then
+  echo "⚠️  render/index.ts 없음 — 스킵"
+  exit 0
+fi
+
+MARKER="// Compact: single line, no wrap, no truncation"
+if grep -q "$MARKER" "$TARGET" 2>/dev/null; then
+  echo "✅ [compact-nowrap] 이미 적용됨 — 스킵"
+  exit 0
+fi
+
+export PATCH_TARGET="$TARGET"
+python3 << 'PYEOF'
+import os, pathlib
+
+target = pathlib.Path(os.environ["PATCH_TARGET"])
+content = target.read_text()
+
+original = "\n".join([
+    "  const physicalLines = lines.flatMap(line => line.split('\\n'));",
+    "  // Only wrap when terminal width is real (known). When width is the",
+    "  // UNKNOWN_TERMINAL_WIDTH fallback, wrapping would use an arbitrary value",
+    "  // and produce incorrect line breaks.",
+    "  const wrapWidth = terminalWidth !== UNKNOWN_TERMINAL_WIDTH ? (terminalWidth ?? 0) : 0;",
+    "  const visibleLines = physicalLines.flatMap(line => wrapLineToWidth(line, wrapWidth));",
+    "",
+    "  for (const line of visibleLines) {",
+    "    const outputLine = `${RESET}${line}`;",
+    "    console.log(outputLine);",
+    "  }",
+])
+
+patched = "\n".join([
+    "  const physicalLines = lines.flatMap(line => line.split('\\n'));",
+    "  // Only wrap when terminal width is real (known). When width is the",
+    "  // UNKNOWN_TERMINAL_WIDTH fallback, wrapping would use an arbitrary value",
+    "  // and produce incorrect line breaks.",
+    "  const wrapWidth = terminalWidth !== UNKNOWN_TERMINAL_WIDTH ? (terminalWidth ?? 0) : 0;",
+    "",
+    "  if (lineLayout === 'compact') {",
+    "    // Compact: single line, no wrap, no truncation — terminal clips naturally",
+    "    for (const line of physicalLines) {",
+    "      console.log(`${RESET}${line}`);",
+    "    }",
+    "  } else {",
+    "    const visibleLines = physicalLines.flatMap(line => wrapLineToWidth(line, wrapWidth));",
+    "    for (const line of visibleLines) {",
+    "      console.log(`${RESET}${line}`);",
+    "    }",
+    "  }",
+])
+
+if original not in content:
+    print("⚠️  [compact-nowrap] 원본 패턴 불일치 — 수동 확인 필요")
+    raise SystemExit(1)
+
+content = content.replace(original, patched, 1)
+target.write_text(content)
+print("✅ [compact-nowrap] 패치 적용 완료")
+PYEOF


### PR DESCRIPTION
## Summary

- `scripts/patch-hud.sh` 를 devex 에 추가 (claude-hud `0.1.0` 의 `wrapWidth` 도입 반영하여 원본 패턴 갱신)
- `hooks/hooks.json` SessionStart 에 등록
- CLAUDE.md 정책: 외부 플러그인 UI 패치는 사내 의존 없으므로 devex 가 적절

## Why

기존 toolkit 의 `patch-hud.sh` 가:
1. 정책상 사내 자원 아님 (claude-hud 패치만)
2. claude-hud `0.1.0` 변수명 변경 (`terminalWidth` → `wrapWidth`) 에 따라 패턴 매칭 실패 → SessionStart 에서 `⚠️ [compact-nowrap] 원본 패턴 불일치` 경고

## Test plan

- [x] sandbox 에서 임시 복사본에 패치 적용 → diff 로 compact/else 분기 정상 변환 확인
- [x] 멱등성 (MARKER grep 으로 재실행 시 스킵)
- [ ] 머지 후 새 세션에서 `✅ [compact-nowrap] 패치 적용 완료` 또는 `이미 적용됨`
- [ ] toolkit 측 잔여 제거 (별 이슈)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)