### PR TITLE
feat: flow / setup 스킬 description 프론트매터 노출 (#84)

### DIFF
--- a/skills/flow/SKILL.md
+++ b/skills/flow/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: flow
+description: 이슈 플로우 단일 진입점 (issue → spec → implement → commit → pr). Git 상태 감지 후 단계별 작업 수행. 트리거 "flow", "플로우", "이슈", "issue", "커밋", "commit", "PR", "풀리퀘", "spec", "명세".
+---
+
 # Issue Flow Skill
 
 이슈 플로우 단일 진입점. 상태를 감지하여 현재 단계에 맞는 작업을 실행한다.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: setup
+description: devex provider 등록·상태 조회·overlay 설정. 이슈 트래커 provider(github 등) 추가 및 host별 오버레이 구성. 트리거 "setup", "설정", "provider 등록", "프로바이더".
+---
+
 # Setup Skill
 
 provider 등록 및 프로젝트 설정 워크플로우


### PR DESCRIPTION
## Summary

- `skills/flow/SKILL.md` 와 `skills/setup/SKILL.md` 상단에 YAML 프론트매터(name + description) 추가
- 자연어 라우팅 미노출 상태에서 노출 상태로 전환
- 본문(트리거 섹션·서브커맨드)은 그대로 유지

Closes #84

## Self-Verify

- [x] YAML frontmatter parse OK (flow: name=flow / desc 155자, setup: name=setup / desc 124자)
- [x] description 트리거 키워드 ↔ CLAUDE.md 스킬 표 정합
- [x] 본문 보존 (변경: +5 / +5 라인만)

## Test Plan

- [ ] PR 머지 후 release.sh minor (devex 5.3.0 통합) 호출
- [ ] reload-plugins 후 새 세션에서 available-skills 리스트에 \`devex:flow\`, \`devex:setup\` 노출 확인
- [ ] 자연어 \"플로우 시작\" / \"setup provider\" 호출 시 라우팅 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)