### PR TITLE
feat: worktree-cleanup state 경로 통일 + is_bare_clone() 방어 보강 (#85)

### DIFF
--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -45,7 +45,27 @@ import json, os, subprocess, shutil
 
 project_root = os.environ["PROJECT_ROOT_ENV"]
 apply = os.environ["APPLY_FLAG"] == "true"
-state_dir = os.path.join(project_root, ".omc", "state")
+state_dir = os.path.join(project_root, ".devex", "state")
+# 5.0.0 리네임. 구 .omc/state/ 가 있으면 fallback 지원 (사용자 미마이그레이션 자산).
+if not os.path.isdir(state_dir):
+    legacy = os.path.join(project_root, ".omc", "state")
+    if os.path.isdir(legacy):
+        state_dir = legacy
+
+
+def is_bare_clone(git_dir):
+    """`git_dir`이 bare clone 인지 git rev-parse 로 확정 검증.
+    HEAD 파일 존재만으로는 정규 clone 내부 .git/ 디렉토리도 통과해 오판 위험.
+    """
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--is-bare-repository"],
+            cwd=git_dir, capture_output=True, text=True
+        )
+        return r.returncode == 0 and r.stdout.strip() == "true"
+    except Exception:
+        return False
+
 
 stale_states = []  # [{file, ticket, reason, repos_missing[]}]
 # state 파일별로 worktree 경로 실존 검증
@@ -89,8 +109,8 @@ for entry in sorted(os.listdir(project_root)):
     bare_path = os.path.join(project_root, entry)
     if not os.path.isdir(bare_path):
         continue
-    if not os.path.isfile(os.path.join(bare_path, "HEAD")):
-        continue  # bare가 아님
+    if not is_bare_clone(bare_path):
+        continue  # bare가 아님 (정규 clone 의 .git/ 오판 방지)
     repo_name = entry[:-4]
     if repo_name in active_repos:
         continue  # stale 아닌 state가 참조
@@ -189,6 +209,20 @@ removed = []
 failed = []
 
 
+def is_bare_clone(git_dir):
+    """`git_dir`이 bare clone 인지 git rev-parse 로 확정 검증.
+    .git 접미사 휴리스틱은 사용자가 정규 clone 을 임의 이름으로 두면 오판 가능.
+    """
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--is-bare-repository"],
+            cwd=git_dir, capture_output=True, text=True
+        )
+        return r.returncode == 0 and r.stdout.strip() == "true"
+    except Exception:
+        return False
+
+
 def resolve_git_dir(repo_name):
     """레포의 git 디렉토리를 찾는다. bare(.git/) 또는 일반 모두 지원."""
     bare_dir = os.path.join(project_root, f"{repo_name}.git")
@@ -226,7 +260,7 @@ for repo_name, repo_info in repos.items():
     # 머지가 정상이어도 fully-merged 판정에 실패해 not-fully-merged false negative가 발생한다.
     # bare clone에 한해 -D로 강제 삭제하고, 일반 레포는 안전 삭제 -d를 유지한다.
     if git_dir:
-        is_bare = git_dir.endswith(".git")
+        is_bare = is_bare_clone(git_dir)
         delete_flag = "-D" if is_bare else "-d"
         r = subprocess.run(
             ["git", "branch", delete_flag, branch],


### PR DESCRIPTION
## Summary

aetherion 사내 사용 중 발견된 워크트리 정리 사고 2건 중 본체에 흡수해야 할 부분 정리.

- **state 경로 통일**: sweep-stale 모드의 `state_dir` 를 `.omc/state/` → `.devex/state/` (5.0.0 컨벤션) 로 통일. 구 경로는 fallback 으로 1회 인식.
- **bare clone 판정 강화**: HEAD 파일 / `.git` 접미사 휴리스틱 → `git rev-parse --is-bare-repository` 로 확정. 정규 clone 내부 `.git/` 오판 차단.

## Cross-link 사고 정리

aetherion #2900/#2707 (cross-link 시 타 티켓 워크트리 삭제) 는 **devex 본체가 이미 다른 방식으로 해결**:

- 5.x 본체는 \"4.5 고아 bare sweep\" / \"4.6 고아 워크트리 sweep\" 블록 자체를 제거 (cleanup L268~271 주석 참조)
- state 에 명시된 레포만 정리 대상 → cross-link 가 있어도 다른 티켓 자산 보존
- → aetherion 로컬의 `protected_worktrees_45` 패치는 본체 흡수 불필요

## Self-Verify

- [x] `bash -n` 통과
- [x] python heredoc 2개 블록 `compile()` 통과
- [x] state 경로 `.devex/state/` + 구 `.omc` fallback 라인 확인
- [x] `is_bare_clone()` 함수 정의 2회 (sweep-stale / 기본 모드 각 1회)

## Test Plan

- [ ] PR 머지 후 release.sh minor (devex 5.3.0 통합) 호출
- [ ] aetherion 디렉토리에서 cleanup 호출 시 정규 clone 보존 확인
- [ ] 구 `.omc/state/` 가 남은 환경에서 fallback 인식 확인

## Follow-up (별 이슈)

- cross-link 사후 검증 가이드 (cleanup 호출 전 protected paths 수집, 호출 후 보존 확인) 를 SKILL.md 에 명시

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)