### PR TITLE
usage:* cwd-based aggregation 모드 추가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 형식: [Semantic Versioning](https://semver.org/)
 
+## [Unreleased]
+
+### Added
+- usage:* 에 cwd-based aggregation 모드 추가 — worktree-per-task 환경에서 ticket 단위 분리 (#91)
+- docs/usage-cwd-aggregation.md 신규
+
 ## [5.5.0] - 2026-05-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ Provider별 Git Identity(user.name, user.email)를 정의하여,
 | `/verify` | 3-Layer 정합성 검증 (Philosophy → Strategy → Tactics) | "이 설계 검증해줘" |
 | `/dependency-map` | 의존성 맵 생성, 변경 영향도 분석 (Mermaid) | "의존성 분석해줘" |
 
+## Usage Tracking
+
+ticket 단위로 토큰·비용을 추적하는 스킬 묶음입니다. worktree-per-task 환경에서 정확히 분리됩니다.
+
+| 스킬 | 역할 |
+|------|------|
+| `/usage-start` | 추적 시작. cwd / project / branch 기록 |
+| `/usage-checkpoint` | 단계 표시 (구현 → 검증 등 구간 분리) |
+| `/usage-snap` | 현재 누적 스냅샷 |
+| `/usage-complete` | 완료 처리 + 리포트 저장 |
+| `/usage-report` | 모든 task 비교 대시보드 |
+
+worktree-per-task 환경에서 ticket 단위 분리가 동작하는 원리·알고리즘은 [docs/usage-cwd-aggregation.md](docs/usage-cwd-aggregation.md) 참조.
+
 ## 스타일 룰 (Style Rules)
 
 블로그·위키·이슈·PoC·데일리로그·동료리뷰·성과평가 등 **모든 한국어 문서**에 적용되는 작성 SSOT 를 제공합니다.

--- a/docs/usage-cwd-aggregation.md
+++ b/docs/usage-cwd-aggregation.md
@@ -1,0 +1,128 @@
+# Usage Tracking — cwd-based Aggregation
+
+`usage:start`, `usage:report`, `usage:complete` 가 worktree-per-task 레이아웃에서 정확히 동작하도록 하는 집계 방식이다.
+
+## 배경
+
+`org-flow` 는 한 ticket 당 한 worktree 를 표준으로 한다 (`worktrees/<repo>/feature-<n>/`). 그러나 Claude Code 는 trace jsonl 파일을 cwd 와 무관하게 **부모 프로젝트 디렉토리 한 곳**에 저장한다.
+
+```
+cwd: /Users/<user>/git-project/<org>/worktrees/<repo>/feature-1234/
+                            ↓
+trace 저장: ~/.claude/projects/-Users-<user>-git-project-<org>/<sessionUuid>.jsonl
+```
+
+`ccusage session` 명령은 디렉토리명을 `sessionId` 로 노출하므로 여러 ticket 의 trace 가 한 `sessionId` 로 누적된다. 결과적으로 `ccusage` 기반 매칭은 `1세션 = 1ticket = N레포` 레이아웃에서 ticket 단위 분리를 못 한다.
+
+## 해결
+
+trace jsonl 의 entry 마다 실제 `cwd` 필드가 자동 기록된다. 워크트리 path 가 그대로 보존된다.
+
+```json
+{"type":"assistant","cwd":"/Users/<user>/git-project/<org>/worktrees/<repo>/feature-1234",
+ "timestamp":"2026-05-19T05:11:27Z","sessionId":"3012248b-...",
+ "message":{"usage":{"input_tokens":6,"output_tokens":213,
+                     "cache_creation_input_tokens":31870,"cache_read_input_tokens":18276}}}
+```
+
+`usage:*` 는 ccusage 대신 trace jsonl 을 직접 파싱하여 `cwd` 별로 토큰을 합산한다. ccusage 매칭은 미설정 환경의 fallback 으로만 사용된다.
+
+## 알고리즘
+
+### 입력
+
+- `tasks.json` 의 task 항목 (각 task 의 `bindings[].cwd` 가 워크트리 path)
+- `~/.claude/projects/<encoded-parent>/<sessionUuid>.jsonl` 트레이스 파일 집합
+
+### 절차
+
+1. 각 task 의 `bindings[].cwd` 를 수집 → 매핑 테이블 `cwd → taskId`
+2. 모든 trace jsonl 을 한 번 순회하면서 `type == "assistant"` 인 entry 만 추출
+3. 각 entry 의 `cwd` 필드로 매핑 테이블 조회 → 해당 taskId 의 누적 합계에 token/cost 추가
+4. cost 계산은 모델별 단가표 (Anthropic 공시) 와 토큰 4종 (input / output / cache_creation / cache_read) 곱
+
+### Sample (python)
+
+```python
+import json, glob, os
+from collections import defaultdict
+
+# 가격표 (예: claude-opus-4-7, USD per 1M tokens)
+PRICING = {
+    "claude-opus-4-7":     {"input": 15.0, "output": 75.0, "cache_creation": 18.75, "cache_read":  1.50},
+    "claude-sonnet-4-6":   {"input":  3.0, "output": 15.0, "cache_creation":  3.75, "cache_read":  0.30},
+}
+
+tasks = json.load(open(os.path.expanduser("~/.claude/usage-tracker/tasks.json")))["tasks"]
+cwd_to_task = {b["cwd"]: tid for tid, t in tasks.items() for b in t.get("bindings", []) if b.get("cwd")}
+
+agg = defaultdict(lambda: {"tokens": 0, "cost": 0.0, "entries": 0})
+for f in glob.glob(os.path.expanduser("~/.claude/projects/*/*.jsonl")):
+    for line in open(f):
+        try:
+            d = json.loads(line)
+        except Exception:
+            continue
+        if d.get("type") != "assistant":
+            continue
+        cwd = d.get("cwd")
+        tid = cwd_to_task.get(cwd)
+        if tid is None:
+            continue
+        u = (d.get("message") or {}).get("usage") or d.get("usage") or {}
+        model = (d.get("message") or {}).get("model", "claude-opus-4-7")
+        p = PRICING.get(model, PRICING["claude-opus-4-7"])
+        toks = (u.get("input_tokens", 0)
+                + u.get("output_tokens", 0)
+                + u.get("cache_creation_input_tokens", 0)
+                + u.get("cache_read_input_tokens", 0))
+        cost = (u.get("input_tokens", 0)              * p["input"]
+              + u.get("output_tokens", 0)             * p["output"]
+              + u.get("cache_creation_input_tokens",0) * p["cache_creation"]
+              + u.get("cache_read_input_tokens", 0)   * p["cache_read"]) / 1_000_000
+        agg[tid]["tokens"] += toks
+        agg[tid]["cost"] += cost
+        agg[tid]["entries"] += 1
+
+for tid, v in agg.items():
+    print(f"{tid:40} entries={v['entries']:>6}  tokens={v['tokens']:>14,}  cost=${v['cost']:>9.2f}")
+```
+
+## 등록 시점 (`usage:start`)
+
+`bindings[]` 에 `cwd` 를 채워야 매칭이 동작한다. `pwd` 결과를 그대로 저장한다.
+
+```json
+"bindings": [
+  {
+    "cwd": "/Users/<user>/git-project/<org>/worktrees/<repo>/feature-1234",
+    "project": "-Users--user--git-project--org",
+    "branch": "feature/1234"
+  }
+]
+```
+
+기존 `project` 필드는 ccusage fallback 용으로 유지한다.
+
+## ccusage Fallback
+
+`tasks.json` 의 task 에 `bindings[].cwd` 가 없거나 trace jsonl 이 손실되었을 때만 기존 `ccusage session` 매칭으로 떨어진다. 새 task 는 자동으로 cwd-based 모드를 우선한다.
+
+## 폐기 조건
+
+- trace jsonl 의 `cwd` 라벨이 Claude Code 향후 버전에서 사라지거나 비어 보고된다면 cwd-based 모드 폐기. fallback (ccusage) 은 남기되 `usage:report` 가 "ticket 단위 분리 불가" 경고를 출력한다.
+- 한 워크트리 안에서 여러 ticket 을 분리 작업하는 패턴이 표준이 되면 cwd 단일 매핑 가정이 깨진다. 그 시점에 별도 마커 (예: `usage:checkpoint`) 로 ticket 전환 명시 필요.
+
+## 검증
+
+PoC 시점 실측:
+
+```
+unique cwds: 96
+  aetherion 루트:                  9590 assistant entries
+  worktrees/aetherion-be/feature-3159  260 entries  ← #3159 작업
+  worktrees/gpulive-portal-fe/feature-3053  776 entries  ← #3053 FE 작업
+  ...
+```
+
+워크트리 path 가 cwd 라벨로 정확히 분리되어 ticket 단위 합산이 동작함을 확인.

--- a/skills/usage-complete/SKILL.md
+++ b/skills/usage-complete/SKILL.md
@@ -30,9 +30,14 @@ cat "$HOME/.claude/usage-tracker/tasks.json"
 
 ### 2. 최종 사용량 데이터 조회
 
-snap과 동일 — ccusage를 조회하여 집계합니다.
+`bindings[].cwd` 가 있으면 trace jsonl 의 `cwd` 필드로 ticket 단위 합산한다 (`usage:report` Mode A 와 동일). 없으면 ccusage fallback.
 
 ```bash
+# Mode A — cwd-based (default for new tasks)
+# python3 으로 ~/.claude/projects/*/*.jsonl 순회 → assistant entry 의 cwd 필드 일치 시 합산
+# 알고리즘은 docs/usage-cwd-aggregation.md 참조
+
+# Mode B — ccusage fallback (bindings[].cwd 가 없는 legacy task 한정)
 ccusage session --since {task.startedAt as YYYYMMDD} --json --breakdown
 ```
 

--- a/skills/usage-report/SKILL.md
+++ b/skills/usage-report/SKILL.md
@@ -26,17 +26,27 @@ description: 모든 추적된 작업의 비교 대시보드를 표시합니다. 
 cat "$HOME/.claude/usage-tracker/tasks.json"
 ```
 
-### 2. Query ccusage
+### 2. Aggregation
+
+두 모드를 순서대로 시도한다.
+
+**Mode A — cwd-based (default).** task 의 `bindings[].cwd` 가 있으면 적용된다. worktree-per-task 환경에서 ticket 단위로 분리된 정확한 비용을 얻는다.
+
+1. `cwd → taskId` 매핑 테이블을 만든다 (`tasks[*].bindings[*].cwd`)
+2. `~/.claude/projects/*/*.jsonl` 의 모든 trace 를 순회하면서 `type == "assistant"` entry 만 추출
+3. 각 entry 의 `cwd` 필드로 매핑 테이블 조회 → 해당 taskId 의 token / cost 누적
+4. cost = 모델별 단가 × (input + output + cache_creation + cache_read)
+
+알고리즘과 sample python 은 [docs/usage-cwd-aggregation.md](../../docs/usage-cwd-aggregation.md) 참조.
+
+**Mode B — ccusage fallback.** `bindings[].cwd` 가 없는 legacy task 한정.
 
 ```bash
 ccusage session --since {earliest task startedAt as YYYYMMDD} --json --breakdown
 ```
 
-각 task의 sessions 배열에서 session ID를 매칭하여 해당 task에 속하는 비용만 집계한다.
-
-**매칭 로직:**
-- task의 bindings[].project와 ccusage의 sessionId를 매칭
-- 같은 프로젝트에 여러 작업이 있을 경우, 세션 시작 시간과 task의 sessions[].id로 구분
+- task 의 `bindings[].project` 와 ccusage 의 `sessionId` 를 매칭
+- 같은 parent project 의 여러 ticket 은 분리되지 않으므로 합산 결과만 표시 + 경고 출력
 
 ### 3. Output comparison table
 

--- a/skills/usage-start/SKILL.md
+++ b/skills/usage-start/SKILL.md
@@ -24,9 +24,16 @@ Start tracking token usage for a new task.
 ### 1. Detect current context
 
 ```bash
-# Get current session ID from the most recent JSONL in this project
-PROJECT_PATH=$(pwd | sed "s|$HOME/||" | sed 's|/|-|g' | sed 's|^|-|')
-SESSION_ID=$(ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs basename | sed 's/.jsonl//')
+# Get absolute cwd (worktree path is preserved here — required for cwd-based aggregation)
+CWD=$(pwd)
+
+# Path-encoded project key (legacy ccusage matching fallback)
+PROJECT_PATH=$(echo "$CWD" | sed "s|$HOME/||" | sed 's|/|-|g' | sed 's|^|-|')
+
+# Most recent session JSONL — Claude Code stores traces under the parent project dir,
+# not under the worktree path. cwd-based aggregation does not depend on this lookup,
+# but it is kept for ccusage fallback.
+SESSION_ID=$(ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/.jsonl//')
 
 # Get current git branch (if git project)
 GIT_BRANCH=$(git branch --show-current 2>/dev/null || echo "none")
@@ -60,6 +67,7 @@ Add to tasks.json:
       "tags": ["{tag1}", "{tag2}"],
       "bindings": [
         {
+          "cwd": "{CWD}",
           "project": "{PROJECT_PATH}",
           "branch": "{GIT_BRANCH}"
         }
@@ -87,5 +95,8 @@ Output:
 - Label: {label}
 - Approach: {approach}
 - Session: {SESSION_ID}
-- Binding: {project} @ {branch}
+- Binding: {CWD} ({project} @ {branch})
+
+`cwd` 가 bindings 에 포함되어야 worktree-per-task 환경에서 ticket 단위 분리가 동작한다.
+상세는 [docs/usage-cwd-aggregation.md](../../docs/usage-cwd-aggregation.md) 참조.
 ```


### PR DESCRIPTION
Closes #91

## What

- usage:start bindings 에 cwd 필드 기록
- usage:report 기본 합산 모드를 cwd-based 로 전환 (ccusage fallback 유지)
- usage:complete 최종 합산 동일 전환
- docs/usage-cwd-aggregation.md 신규 — 알고리즘·sample
- README 짧은 usage 섹션 + docs 링크

## Why

worktree-per-task 레이아웃에서 ticket 단위 비용 분리가 필요합니다. Claude Code 가 trace jsonl 을 부모 디렉토리에 합쳐 저장하므로 ccusage 의 sessionId 매칭은 ticket 들을 한 묶음으로 보고합니다. trace jsonl entry 의 cwd 필드를 직접 합산하여 ticket-per-worktree 매핑을 살립니다.

## 폐기 조건

trace jsonl 의 `cwd` 라벨이 Claude Code 향후 버전에서 사라지거나 비어 보고되면 cwd-based 모드 폐기. fallback (ccusage) 은 남기되 usage:report 가 "ticket 단위 분리 불가" 경고를 출력하는 방향으로 단순화.

## 검증

PoC 시점 로컬 trace 96 unique cwds 확인, worktree path 그대로 cwd 필드에 기록됨. 본 PR 머지 후 다음 `usage:start` 호출 시 새 bindings 스키마 (cwd 포함) 가 적용되며, 그 다음 `usage:report` 가 cwd-based 합산을 출력합니다.